### PR TITLE
fix: allow_copiers key name in dashboard

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -10,13 +10,13 @@ const Dashboard = () => {
     const { settings, isLoading: settingsLoading } = useSettings();
     const [userType, setUserType] = useState(() => {
         // Set initial state based on settings if available
-        return settings?.allow_copier ? "trader" : "copier";
+        return settings?.allow_copiers ? "trader" : "copier";
     });
 
     useEffect(() => {
         console.log("Settings updated:", settings);
         if (settings) {
-            const newUserType = settings.allow_copier ? "trader" : "copier";
+            const newUserType = settings.allow_copiers ? "trader" : "copier";
             console.log("Setting userType to:", newUserType);
             setUserType(newUserType);
         }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the key name from 'allow_copier' to 'allow_copiers' in the Dashboard component to ensure proper functionality.