### PR TITLE
feat: fetch and display balance in account switcher

### DIFF
--- a/src/components/AccountSelector.jsx
+++ b/src/components/AccountSelector.jsx
@@ -4,7 +4,12 @@ import { useAuth } from "../hooks/useAuth.jsx";
 import { DropdownButton } from "@deriv-com/quill-ui";
 import { LegacyLogout1pxIcon } from "@deriv/quill-icons";
 
-const AccountSelector = ({ defaultAccount, otherAccounts, onLogout }) => {
+const AccountSelector = ({
+    defaultAccount,
+    otherAccounts,
+    onLogout,
+    balances,
+}) => {
     const [selectedAccount, setSelectedAccount] = useState(defaultAccount);
     const { updateAccounts } = useAuth();
 
@@ -26,8 +31,12 @@ const AccountSelector = ({ defaultAccount, otherAccounts, onLogout }) => {
     const dropdownOptions = [
         ...allAccounts.map((account) => ({
             id: account.account,
-            label: `${account.account}${
-                account.currency ? ` (${account.currency})` : ""
+            label: `${account.account} | ${
+                balances[account.account]
+                    ? `${balances[account.account].balance.toFixed(2)} ${
+                          balances[account.account].currency
+                      }`
+                    : `0.00 ${account.currency}`
             }`,
             value: account.account,
             onClick: () => handleAccountSelect(account),
@@ -42,7 +51,7 @@ const AccountSelector = ({ defaultAccount, otherAccounts, onLogout }) => {
     ];
 
     return (
-        <div>
+        <div className="max-w-fit [&_*]:max-w-fit">
             <DropdownButton
                 actionSheetFooter={{
                     primaryAction: {
@@ -54,10 +63,12 @@ const AccountSelector = ({ defaultAccount, otherAccounts, onLogout }) => {
                 color="black"
                 contentHeight="sm"
                 contentTitle=""
-                label={`${selectedAccount.account}${
-                    selectedAccount.currency
-                        ? ` (${selectedAccount.currency})`
-                        : ""
+                label={`${selectedAccount.account} | ${
+                    balances[selectedAccount.account]
+                        ? `${balances[selectedAccount.account].balance.toFixed(
+                              2
+                          )} ${balances[selectedAccount.account].currency}`
+                        : `0.00 ${selectedAccount.currency}`
                 }`}
                 onClose={() => {}}
                 onOpen={() => {}}
@@ -87,6 +98,13 @@ AccountSelector.propTypes = {
         })
     ).isRequired,
     onLogout: PropTypes.func.isRequired,
+    balances: PropTypes.objectOf(
+        PropTypes.shape({
+            balance: PropTypes.number.isRequired,
+            currency: PropTypes.string.isRequired,
+            loginid: PropTypes.string.isRequired,
+        })
+    ).isRequired,
 };
 
 export default AccountSelector;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,6 +3,7 @@ import AccountSelector from "./AccountSelector";
 import { getConfig } from "../config";
 import derivIcon from "../assets/deriv-icon.svg";
 import { useAuth } from "../hooks/useAuth.jsx";
+import useBalance from "../hooks/useBalance";
 
 const Header = () => {
     const {
@@ -12,6 +13,7 @@ const Header = () => {
         isAuthorized,
         isLoading,
     } = useAuth();
+    const balances = useBalance();
     const config = getConfig();
     const handleLogout = () => {
         clearAccounts();
@@ -58,6 +60,7 @@ const Header = () => {
                                         defaultAccount={defaultAccount}
                                         otherAccounts={otherAccounts}
                                         onLogout={handleLogout}
+                                        balances={balances}
                                     />
                                 ) : (
                                     <Button

--- a/src/hooks/useBalance.js
+++ b/src/hooks/useBalance.js
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import useWebSocket from './useWebSocket';
+import useAuth from './useAuth';
+
+const useBalance = () => {
+    const [balances, setBalances] = useState({});
+    const { sendMessage, isConnected } = useWebSocket();
+    const { isAuthorized, isLoading } = useAuth();
+
+    useEffect(() => {
+        // Only subscribe if connected, authorized, and not loading
+        if (!isConnected || !isAuthorized || isLoading) return;
+
+        // Subscribe to balance updates
+        const subscribeToBalance = () => {
+            sendMessage(
+                {
+                    balance: 1,
+                    subscribe: 1,
+                    account: "all"
+                },
+                (response) => {
+                    if (response.error) {
+                        console.error('Balance subscription error:', response.error);
+                        return;
+                    }
+
+                    if (response.balance) {
+                        setBalances(prevBalances => ({
+                            ...prevBalances,
+                            [response.balance.loginid]: response.balance
+                        }));
+                    }
+                }
+            );
+        };
+
+        subscribeToBalance();
+
+        // Cleanup subscription on unmount or when auth state changes
+        return () => {
+            if (isConnected) {
+                sendMessage({
+                    balance: 1,
+                    subscribe: 0,
+                    account: "all"
+                });
+            }
+        };
+    }, [isConnected, isAuthorized, isLoading, sendMessage]);
+
+    return balances;
+};
+
+export default useBalance;


### PR DESCRIPTION
## Summary by Sourcery

Fetch and display the account balance in the account switcher.

New Features:
- Display the balance of each account alongside the account number in the account switcher.

Tests:
- Add tests for the `useBalance` hook.