### PR TITLE
fix: show trader banner on disabling trader mode

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,57 +1,54 @@
-import { useState, useEffect } from "react";
-import useSettings from "../hooks/useSettings";
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { ToggleSwitch, Text } from "@deriv-com/quill-ui";
 
-const Settings = () => {
-    const { settings, updateSettings, isLoading } = useSettings();
-    const [allowCopiers, setAllowCopiers] = useState(false);
-
-    useEffect(() => {
-        if (settings?.allow_copiers !== undefined) {
-            setAllowCopiers(settings.allow_copiers);
-        }
-    }, [settings]);
+const Settings = ({ settings, updateSettings, onChangeSettings }) => {
+    const [allowCopiers, setAllowCopiers] = useState(
+        settings?.allow_copiers ?? false
+    );
 
     const handleTraderToggle = async () => {
         try {
             await updateSettings({ allow_copiers: !allowCopiers ? 1 : 0 });
             setAllowCopiers(!allowCopiers);
+            onChangeSettings?.();
         } catch (error) {
             console.error("Failed to update trader status:", error);
         }
     };
 
-    if (isLoading) {
-        return (
-            <div className="p-4">
-                <div className="animate-pulse h-8 w-32 bg-gray-200 rounded mb-4"></div>
-            </div>
-        );
-    }
-
     return (
-        <div className="p-4">
-            <h2 className="text-2xl font-bold mb-6">Settings</h2>
-            <div className="bg-white rounded-xl p-6 shadow-sm">
-                <div className="flex items-center justify-between">
-                    <div>
-                        <h3 className="text-lg font-semibold text-solid-slate-1400">Trader Mode</h3>
-                        <p className="text-solid-slate-700 text-sm mt-1">
+        <div className="p-8 bg-white h-full space-y-8">
+            <Text as="h2" size="xl" bold>
+                Settings
+            </Text>
+            <div>
+                <div className="flex items-center justify-between gap-16">
+                    <div className="space-y-2">
+                        <Text as="h3" size="lg" bold>
+                            Trader Mode
+                        </Text>
+                        <Text size="sm" color="secondary">
                             Enable this to allow others to copy your trades
-                        </p>
+                        </Text>
                     </div>
-                    <label className="relative inline-flex items-center cursor-pointer">
-                        <input
-                            type="checkbox"
-                            className="sr-only peer"
-                            checked={allowCopiers}
-                            onChange={handleTraderToggle}
-                        />
-                        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                    </label>
+                    <ToggleSwitch
+                        checked={allowCopiers}
+                        onChange={handleTraderToggle}
+                        size="lg"
+                    />
                 </div>
             </div>
         </div>
     );
+};
+
+Settings.propTypes = {
+    settings: PropTypes.shape({
+        allow_copiers: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
+    }),
+    updateSettings: PropTypes.func.isRequired,
+    onChangeSettings: PropTypes.func,
 };
 
 export default Settings;

--- a/src/components/TraderDashboard.jsx
+++ b/src/components/TraderDashboard.jsx
@@ -1,11 +1,11 @@
+import { useState } from "react";
+import { Spinner, SectionMessage } from "@deriv-com/quill-ui";
 import useSettings from "../hooks/useSettings";
 import useCopyTradersList from "../hooks/useCopyTradersList";
 import TraderStatistics from "./TraderStatistics";
 import TraderBanner from "./TraderBanner";
 import TokenManagement from "./TokenManagement";
 import Settings from "./Settings";
-import { Spinner, SectionMessage } from "@deriv-com/quill-ui";
-import { useState } from "react";
 import TraderDesktopNavigation from "./TraderDesktopNavigation";
 import TraderMobileNavigation from "./TraderMobileNavigation";
 
@@ -51,7 +51,11 @@ const TraderDashboard = () => {
                         ) : selectedMenu === "tokens" ? (
                             <TokenManagement />
                         ) : (
-                            <Settings />
+                            <Settings
+                                settings={settings}
+                                updateSettings={updateSettings}
+                                onChangeSettings={fetchSettings}
+                            />
                         )}
                     </div>
 


### PR DESCRIPTION
## Summary by Sourcery

Update the settings UI to refresh the trader banner when trader mode is toggled.

New Features:
- Add a callback to the `Settings` component to refresh settings after an update.

Enhancements:
- Improve the Settings component UI by using components from the `@deriv-com/quill-ui` library and updating the layout.